### PR TITLE
Work 3.0.35.1 revup

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -11,7 +11,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
 )
 
-VERSION = version_info_t(3, 0, 35, 1, '')
+VERSION = version_info_t(3, 0, 35, 2, '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1026,14 +1026,45 @@ class Transport(virtual.Transport):
         cycle._on_connection_disconnect = _on_disconnect
 
         def on_poll_start():
-            cycle_poll_start()
-            [add_reader(fd, on_readable, fd) for fd in cycle.fds]
+            try:
+                cycle_poll_start()
+            except redis.exceptions.ConnectionError:
+                # Catch any redis ConnectionErrors. It was most likely caused
+                # by the `_on_disconnect_connect` handler, which we don't care
+                # about. We'll create a new connection on the next attempt.
+                pass
+            else:
+                for fd in cycle.fds:
+                    try:
+                        add_reader(fd, on_readable, fd)
+                    except IOError, e:
+                        # If we get an IOError where the errno is 9, that means
+                        # we tried to register a closed file descriptor with
+                        # the poller. This is a result of a race condition.
+                        # Skip the bad fd and try the other ones. The next
+                        # cycle will detect the dead fd and clear it out.
+                        if getattr(e, 'errno') != 9:
+                            raise
+                    except redis.exceptions.ConnectionError:
+                        # Catch any redis ConnectionErrors. It was most likely
+                        # caused by the `_on_disconnect_connect` handler, which
+                        # we don't care about. We'll create a new connection on
+                        # the next attempt.
+                        pass
+
         loop.on_tick.add(on_poll_start)
         loop.call_repeatedly(10, cycle.maybe_restore_messages)
 
     def on_readable(self, fileno):
         """Handle AIO event for one of our file descriptors."""
-        item = self.cycle.on_readable(fileno)
+        try:
+            item = self.cycle.on_readable(fileno)
+        except Empty:
+            # This `on_readable` method used to return None when the file
+            # descriptor could not be found. Now there's a chance it'll raise
+            # the Empty exception. Catch Empty and set item to None to
+            # replicate old functionality.
+            item = None
         if item:
             message, queue = item
             if not queue or queue not in self._callbacks:


### PR DESCRIPTION
Add more error handling to try and prevent exceptions from being propagated up to the celery Consumer.

We want to avoid having the consumer being restarted at all costs, because when it restores unacknowledged messages, tasks we're currently processing are included in that set of messages.

ping @aredalen @msteffeck 